### PR TITLE
Crawler diff to index

### DIFF
--- a/src/crawler/README.md
+++ b/src/crawler/README.md
@@ -19,7 +19,7 @@
 
     scrapy crawl parldata -a term_id=36
 
-Where term_id represents the parlamentary cycle:
+Where term_id represents the parliamentary cycle:
 * 36: 1998-2002
 * 37: 2002-2006
 * 38: 2006-2010
@@ -27,7 +27,7 @@ Where term_id represents the parlamentary cycle:
 * 40: 2014-
 
 
-The results will be exported to json files named by the crawler, term and crawliing timestamp.
+The results will be exported to json files named by the crawler, term and crawling timestamp.
 
 
 If not all of the speeches are required to be crawled you can restrict each crawler to visit the pages only the specified sitting and speeches:
@@ -35,3 +35,9 @@ If not all of the speeches are required to be crawled you can restrict each craw
      scrapy crawl parldata_1990-1994 -a sitting_id=1
 
      scrapy crawl parldata_1990-1994 -a sitting_id=1 -a speech_id=1
+
+You can check if there are new speeches uploaded which are not indexed yet and crawl only the missing plenary sittings to make a diff file to your index (this will only check the index on the level of plenary sittings, not speeches):
+
+    scrapy crawl parldata -a term_id=41 -a index_url=http://127.0.0.1:9200/parldata
+
+The `index_url` argument can not be used with the `sitting_id` and `speech_id` arguments, if all of the parameters are specified the id filters will be ignored.


### PR DESCRIPTION
An elasticsearch url can be specified for the crawler to check which plenary sittings are missing from the index and crawl only them.